### PR TITLE
fix(action): Update auto-bump-version.yml with write permission

### DIFF
--- a/.github/workflows/auto-bump-version.yml
+++ b/.github/workflows/auto-bump-version.yml
@@ -18,6 +18,8 @@ jobs:
   bump-version:
     name: 'Bump Version on main'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - name: 'Checkout source code'


### PR DESCRIPTION
A minor fix has been made to the version bump GitHub action. The issue has been resolved and the action should now work as intended. This update should help ensure that your workflow runs smoothly and efficiently. Let me know if you have any questions or concerns about this update.