### PR TITLE
Refactor blog post sorting by published date

### DIFF
--- a/app/_db/blog.js
+++ b/app/_db/blog.js
@@ -38,6 +38,7 @@ function getMDXData(dir) {
       metadata,
       slug,
       content,
+      date: new Date(metadata.publishedAt), // Precompute date
     };
   });
 }
@@ -47,10 +48,8 @@ export function getBlogPosts() {
 
   // Sort posts by publishedAt date (newest first)
   posts.sort((a, b) => {
-    // Convert publishedAt to Date objects for comparison
-    const dateA = new Date(a.metadata.publishedAt);
-    const dateB = new Date(b.metadata.publishedAt);
-    return dateB - dateA; // Descending order (latest first)
+    // Use precomputed date for comparison
+    return b.date - a.date; // Descending order (latest first)
   });
 
   return posts;

--- a/app/_db/blog.js
+++ b/app/_db/blog.js
@@ -43,5 +43,15 @@ function getMDXData(dir) {
 }
 
 export function getBlogPosts() {
-  return getMDXData(path.join(process.cwd(), "content"));
+  const posts = getMDXData(path.join(process.cwd(), "content"));
+
+  // Sort posts by publishedAt date (newest first)
+  posts.sort((a, b) => {
+    // Convert publishedAt to Date objects for comparison
+    const dateA = new Date(a.metadata.publishedAt);
+    const dateB = new Date(b.metadata.publishedAt);
+    return dateB - dateA; // Descending order (latest first)
+  });
+
+  return posts;
 }


### PR DESCRIPTION
Refactor the blog post retrieval process to sort posts by their published date, ensuring the newest posts appear first. Optimize date handling by precomputing the date during data extraction, which enhances performance and aligns with project standards for efficient data management. This change improves the user experience by presenting the most relevant content at the top.