### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/close-stale-pr-and-issues.yml
+++ b/.github/workflows/close-stale-pr-and-issues.yml
@@ -1,4 +1,8 @@
 name: 'Close Stale Issues and PRs'
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
 on:
   schedule:
     - cron: '30 1 * * *'
@@ -24,4 +28,3 @@ jobs:
           exempt-all-pr-assignees: true
           remove-issue-stale-when-updated: true
           remove-pr-stale-when-updated: true
-


### PR DESCRIPTION
Potential fix for [https://github.com/Justinjdaniel/justinjdaniel.com/security/code-scanning/1](https://github.com/Justinjdaniel/justinjdaniel.com/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the workflow's purpose (closing stale issues and pull requests), the required permissions are:
- `contents: read` (to read repository contents if necessary).
- `issues: write` (to update and close issues).
- `pull-requests: write` (to update and close pull requests).

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or within the `stale` job to limit its scope. In this case, adding it at the root level is more concise and ensures consistency.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
